### PR TITLE
Replace request second->first from http to local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ﻿bin
 obj
+.vs
+*.user

--- a/First/Controllers/WeatherForecastController.cs
+++ b/First/Controllers/WeatherForecastController.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using First.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 
 namespace First.Controllers
 {
@@ -11,29 +9,17 @@ namespace First.Controllers
 	[Route("[controller]")]
 	public class WeatherForecastController : ControllerBase
 	{
-		private static readonly string[] Summaries = new[]
-		{
-			"Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-		};
+        private readonly IFirstWeatherService _weatherService;
 
-		private readonly ILogger<WeatherForecastController> _logger;
-
-		public WeatherForecastController(ILogger<WeatherForecastController> logger)
-		{
-			_logger = logger;
-		}
+        public WeatherForecastController(IFirstWeatherService weatherService)
+        {
+            _weatherService = weatherService;
+        }
 
 		[HttpGet]
-		public IEnumerable<FirstWeatherForecast> Get()
-		{
-			var rng = new Random();
-			return Enumerable.Range(1, 5).Select(index => new FirstWeatherForecast
-				{
-					Date = DateTime.Now.AddDays(index),
-					TemperatureC = rng.Next(-20, 55),
-					Summary = Summaries[rng.Next(Summaries.Length)]
-				})
-				.ToArray();
-		}
+		public async Task<IEnumerable<FirstWeatherForecast>> Get()
+        {
+            return await _weatherService.GetForecastAsync();
+        }
 	}
 }

--- a/First/FirstWeatherForecast.cs
+++ b/First/FirstWeatherForecast.cs
@@ -8,8 +8,8 @@ namespace First
 
 		public int TemperatureC { get; set; }
 
-		public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+        public int TemperatureF { get; set; }
 
-		public string Summary { get; set; }
+        public string Summary { get; set; }
 	}
 }

--- a/First/Services/FirstWeatherService.cs
+++ b/First/Services/FirstWeatherService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace First.Services
+{
+    public class FirstWeatherService : IFirstWeatherService
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        public Task<FirstWeatherForecast[]> GetForecastAsync()
+        {
+            var rng = new Random();
+            var result = Enumerable
+                .Range(1, 5)
+                .Select(_ => rng.Next(-20, 55))
+                .Select((index, x) => new FirstWeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = x,
+                    TemperatureF = 32 + (int)(x / 0.5556),
+                    Summary = Summaries[rng.Next(Summaries.Length)]
+                })
+                .ToArray();
+            
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/First/Services/IFirstWeatherService.cs
+++ b/First/Services/IFirstWeatherService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace First.Services
+{
+    public interface IFirstWeatherService
+    {
+        Task<FirstWeatherForecast[]> GetForecastAsync();
+    }
+}

--- a/First/Startup.cs
+++ b/First/Startup.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using First.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
@@ -28,7 +30,9 @@ namespace First
 		{
 			services.AddControllers();
 			services.AddSwaggerGen(c => { c.SwaggerDoc("v1", new OpenApiInfo { Title = "First", Version = "v1" }); });
-		}
+
+            services.AddScoped<IFirstWeatherService, FirstWeatherService>();
+        }
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/First/Startup.cs
+++ b/First/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using First.Services;
 using Microsoft.AspNetCore.Builder;
@@ -31,7 +32,7 @@ namespace First
 			services.AddControllers();
 			services.AddSwaggerGen(c => { c.SwaggerDoc("v1", new OpenApiInfo { Title = "First", Version = "v1" }); });
 
-            services.AddScoped<IFirstWeatherService, FirstWeatherService>();
+            services.AddFirstServices();
         }
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -53,4 +54,13 @@ namespace First
 			app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
 		}
 	}
+
+    public static class ServiceCollectionExtensions
+	{
+        public static void AddFirstServices(this IServiceCollection services)
+        {
+            services.AddScoped<IFirstWeatherService, FirstWeatherService>();
+		}
+
+    }
 }

--- a/Joined/Joined.csproj
+++ b/Joined/Joined.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>

--- a/Joined/Program.cs
+++ b/Joined/Program.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using First.Services;
 using Joined.ServiceInstance;
+using Joined.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Second.Services;
 
 namespace Joined
 {
@@ -29,7 +32,13 @@ namespace Joined
 						configuration,
 						DaemonNames,
 						args);
-					
+
+					//First Services
+                    services.AddScoped<IFirstWeatherService, FirstWeatherService>();
+
+					//Second services
+                    services.AddScoped<IFirstClient, LocalFirstClient>();
+
 					services.AddHostedService<DaemonBackgroundService<First.Program>>();
 					services.AddHostedService<DaemonBackgroundService<Second.Program>>();
 				})

--- a/Joined/Program.cs
+++ b/Joined/Program.cs
@@ -1,14 +1,9 @@
 using System;
 using System.Collections.Generic;
-using First;
-using First.Services;
 using Joined.ServiceInstance;
-using Joined.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Second;
-using Second.Services;
 
 namespace Joined
 {
@@ -35,12 +30,7 @@ namespace Joined
 						DaemonNames,
 						args);
 
-					services.AddFirstServices();
-
-					services.AddSecondServices(configuration);
-                    services.AddScoped<IFirstClient, LocalFirstClient>();
-
-					services.AddHostedService<DaemonBackgroundService<First.Program>>();
+                    services.AddHostedService<DaemonBackgroundService<First.Program>>();
 					services.AddHostedService<DaemonBackgroundService<Second.Program>>();
 				})
 				.ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });

--- a/Joined/Program.cs
+++ b/Joined/Program.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using First;
 using First.Services;
 using Joined.ServiceInstance;
 using Joined.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Second;
 using Second.Services;
 
 namespace Joined
@@ -33,10 +35,9 @@ namespace Joined
 						DaemonNames,
 						args);
 
-					//First Services
-                    services.AddScoped<IFirstWeatherService, FirstWeatherService>();
+					services.AddFirstServices();
 
-					//Second services
+					services.AddSecondServices(configuration);
                     services.AddScoped<IFirstClient, LocalFirstClient>();
 
 					services.AddHostedService<DaemonBackgroundService<First.Program>>();

--- a/Joined/ServiceInstance/DaemonBackgroundService.cs
+++ b/Joined/ServiceInstance/DaemonBackgroundService.cs
@@ -179,7 +179,9 @@ namespace Joined.ServiceInstance
 			hostBuilder.ConfigureAppConfiguration((context, builder) =>
 			{
 				builder.Sources.Clear();
-				builder.AddInMemoryCollection(_daemonConfiguration);
+                builder.AddInMemoryCollection(_daemonConfiguration);
+                builder.AddJsonFile("appsettings.json");
+                builder.AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json");
 			});
 		}
 

--- a/Joined/ServiceInstance/DaemonBackgroundService.cs
+++ b/Joined/ServiceInstance/DaemonBackgroundService.cs
@@ -4,10 +4,14 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using First;
+using Joined.Services;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Second.Services;
 
 namespace Joined.ServiceInstance
 {
@@ -86,6 +90,11 @@ namespace Joined.ServiceInstance
 				}
 
 				ConfigureDaemonConfiguration(hostBuilder);
+                hostBuilder.ConfigureServices((ctx, services) =>
+                {
+					services.AddFirstServices();
+                    services.AddScoped<IFirstClient, LocalFirstClient>();
+				});
 				var host = hostBuilder.Build();
 
 				try

--- a/Joined/Services/LocalFirstClient.cs
+++ b/Joined/Services/LocalFirstClient.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using First.Services;
+using Second.Services;
+
+namespace Joined.Services
+{
+    public class LocalFirstClient : IFirstClient
+    {
+        private readonly IFirstWeatherService _firstWeatherService;
+
+        public LocalFirstClient(IFirstWeatherService firstWeatherService)
+        {
+            _firstWeatherService = firstWeatherService;
+        }
+
+        public async Task<FirstInSecondWeatherForecast[]> GetForecastAsync()
+        {
+            var data = await _firstWeatherService.GetForecastAsync();
+            return data.Select(x => new FirstInSecondWeatherForecast
+            {
+                TemperatureF = x.TemperatureF,
+                TemperatureC = x.TemperatureC,
+                Date = x.Date,
+                Summary = x.Summary
+            }).ToArray();
+        }
+    }
+}

--- a/Joined/appsettings.json
+++ b/Joined/appsettings.json
@@ -6,5 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "First": {
+    "Url": "http://localhost:5001/"
+  }
 }

--- a/Second/Controllers/SecondWeatherForecastController.cs
+++ b/Second/Controllers/SecondWeatherForecastController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
+using Second.Services;
 
 namespace Second.Controllers
 {
@@ -11,20 +11,21 @@ namespace Second.Controllers
 	[Route("[controller]")]
 	public class SecondWeatherForecastController : ControllerBase
 	{
-		private static readonly string[] Summaries = new[]
+        private readonly IFirstClient _firstClient;
+
+        private static readonly string[] Summaries = new[]
 		{
 			"Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 		};
 
-		private readonly ILogger<SecondWeatherForecastController> _logger;
 
-		public SecondWeatherForecastController(ILogger<SecondWeatherForecastController> logger)
-		{
-			_logger = logger;
-		}
+		public SecondWeatherForecastController(IFirstClient firstClient)
+        {
+            _firstClient = firstClient;
+        }
 
 		[HttpGet]
-		public IEnumerable<SecondWeatherForecast> Get()
+		public IEnumerable<SecondWeatherForecast> GetSecond()
 		{
 			var rng = new Random();
 			return Enumerable.Range(1, 5).Select(index => new SecondWeatherForecast
@@ -35,5 +36,11 @@ namespace Second.Controllers
 				})
 				.ToArray();
 		}
-	}
+
+        [HttpGet("first")]
+        public Task<FirstInSecondWeatherForecast[]> GetFirst()
+        {
+            return _firstClient.GetForecastAsync();
+        }
+    }
 }

--- a/Second/Services/FirstClient.cs
+++ b/Second/Services/FirstClient.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Second.Services
+{
+    public class FirstClient : IFirstClient
+    {
+        private readonly IOptions<FirstConfiguration> _options;
+
+        public FirstClient(IOptions<FirstConfiguration> options)
+        {
+            _options = options;
+        }
+
+        public Task<FirstInSecondWeatherForecast[]> GetForecastAsync()
+        {
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri(_options.Value.Url)
+            };
+
+            return client.GetFromJsonAsync<FirstInSecondWeatherForecast[]>("WeatherForecast");
+        }
+    }
+}

--- a/Second/Services/FirstConfiguration.cs
+++ b/Second/Services/FirstConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Second.Services
+{
+    public class FirstConfiguration
+    {
+        public string Url { get; set; }
+    }
+}

--- a/Second/Services/FirstInSecondWeatherForecast.cs
+++ b/Second/Services/FirstInSecondWeatherForecast.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Second.Services
+{
+    public class FirstInSecondWeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF { get; set; }
+
+        public string Summary { get; set; }
+    }
+}

--- a/Second/Services/IFirstClient.cs
+++ b/Second/Services/IFirstClient.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Second.Services
+{
+    public interface IFirstClient
+    {
+        Task<FirstInSecondWeatherForecast[]> GetForecastAsync();
+    }
+}

--- a/Second/Startup.cs
+++ b/Second/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Second.Services;
 
 namespace Second
 {
@@ -28,7 +29,10 @@ namespace Second
 		{
 			services.AddControllers();
 			services.AddSwaggerGen(c => { c.SwaggerDoc("v1", new OpenApiInfo { Title = "Second", Version = "v1" }); });
-		}
+
+			services.AddScoped<IFirstClient, FirstClient>();
+            services.Configure<FirstConfiguration>(Configuration.GetSection("First"));
+        }
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/Second/Startup.cs
+++ b/Second/Startup.cs
@@ -30,8 +30,7 @@ namespace Second
 			services.AddControllers();
 			services.AddSwaggerGen(c => { c.SwaggerDoc("v1", new OpenApiInfo { Title = "Second", Version = "v1" }); });
 
-			services.AddScoped<IFirstClient, FirstClient>();
-            services.Configure<FirstConfiguration>(Configuration.GetSection("First"));
+			services.AddSecondServices(Configuration);
         }
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -53,4 +52,13 @@ namespace Second
 			app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
 		}
 	}
+
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddSecondServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddScoped<IFirstClient, FirstClient>();
+            services.Configure<FirstConfiguration>(configuration.GetSection("First"));
+		}
+    }
 }

--- a/Second/appsettings.json
+++ b/Second/appsettings.json
@@ -6,5 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "First": {
+    "Url": "https://localhost:5003/"
+  }
 }


### PR DESCRIPTION
This sample show how to use several modules in the same process without transactions.

It is needed to register all services of first module to DI container of second module to replace http request by local service. 
Second module will create a service from first module. To replace all cross-modules http requests by local requests it is needed to register services from all modules to each module DI container. 

To replace MessageBroker by local call it is needed to keep it async (caller doesn't wait when handler 's work will be finished).

And config files should have the same names for common settings and different names for different settings (connections to different databases).

After start Joined:
http://localhost:5001/WeatherForecast - to call first
http://localhost:5002/SecondWeatherForecast/first - to call second